### PR TITLE
Add boy gender reveal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ xdg-open index.html        # Linux
 - `fontSub` – font family for the secondary line
 - `fontDate` – font family for the date line
 - `fontFrom` – font family for the closing signature
-- `s` – optional surprise code. Set `s=2` to show a pink confetti overlay with "IT'S A GIRL!" text and matching icons.
+- `s` – optional surprise code. Set `s=1` for a blue "IT'S A BOY!" reveal or `s=2` for a pink "IT'S A GIRL!" reveal, each with matching icons and confetti.
 
 Font parameters expect Google Fonts family names just like `font`, using `+` instead of spaces.
 
@@ -57,6 +57,10 @@ index.html?main=We%E2%80%99re%20expecting&font=Playfair+Display
 
 ```
 index.html?s=2
+```
+
+```
+index.html?s=1
 ```
 
 ```

--- a/index.html
+++ b/index.html
@@ -537,10 +537,11 @@
           "instructionsOverlay",
         );
         const genderOverlay = document.getElementById("genderOverlay");
+        const genderText = genderOverlay.querySelector(".gender-text");
         const params = getParams();
         const surpriseCode = params.s;
         const isGirl = surpriseCode === "2" || (params.gender || "").toLowerCase() === "girl";
-        const isBoy = (params.gender || "").toLowerCase() === "boy";
+        const isBoy = surpriseCode === "1" || (params.gender || "").toLowerCase() === "boy";
         const safeTextColor = sanitizeColor(params.textcolor, "#ffffff");
         const safeOutlineColor = sanitizeColor(params.outlinecolor, "#7e5e4f");
 
@@ -715,7 +716,7 @@
             if (isGirl) finalIcon = icons[5];
             else if (isBoy) finalIcon = icons[2];
             const endCallback =
-              isGirl
+              isGirl || isBoy
                 ? () => setTimeout(showGenderReveal, 500)
                 : () => setTimeout(showReveal, 500);
             reels.forEach((reel, i) => {
@@ -882,14 +883,28 @@
         function showGenderReveal() {
           genderOverlay.style.opacity = "1";
           genderOverlay.style.pointerEvents = "auto";
-          createConfetti([
-            "#ffa98e",
-            "#FFB6C1",
-            "#FFC0CB",
-            "#FFFFFF",
-            "#FF1493",
-            "#DB7093",
-          ]);
+          if (isBoy) {
+            genderText.textContent = "IT'S A BOY!";
+            genderText.style.color = "#ffffff";
+            genderText.style.textShadow =
+              "-3px -3px 0 #ffffff, 3px -3px 0 #ffffff, -3px 3px 0 #ffffff, 3px 3px 0 #ffffff";
+            genderOverlay.style.background = "rgba(203, 226, 207, 0.6)";
+            createConfetti(["#cbe2cf", "#ffffff", "#ffd700"]);
+          } else {
+            genderText.textContent = "IT'S A GIRL!";
+            genderText.style.color = "#ffa98e";
+            genderText.style.textShadow =
+              "-3px -3px 0 #ffffff, 3px -3px 0 #ffffff, -3px 3px 0 #ffffff, 3px 3px 0 #ffffff";
+            genderOverlay.style.background = "rgba(255, 255, 255, 0.6)";
+            createConfetti([
+              "#ffa98e",
+              "#FFB6C1",
+              "#FFC0CB",
+              "#FFFFFF",
+              "#FF1493",
+              "#DB7093",
+            ]);
+          }
           setTimeout(() => {
             genderOverlay.style.opacity = "0";
             genderOverlay.style.pointerEvents = "none";


### PR DESCRIPTION
## Summary
- document new `s=1` URL parameter
- allow a blue boy overlay with confetti when `s=1` or `gender=boy`
- land slot machine on the boy icon

## Testing
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_688571dd2570832f8529f1038002c984