### PR TITLE
Simplify URL customization to gender and language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Big Reveal
 
-This project contains a single HTML file that displays an interactive slot machine-style reveal. Spinning the reels a few times eventually triggers a personalized message overlay with optional confetti effects. It's designed for fun occasions like pregnancy announcements, graduations, or other surprises.
+This project contains a single HTML file that displays an interactive slot machine-style reveal. Spinning the reels a few times eventually triggers a celebratory message overlay with optional confetti effects. It's designed for fun occasions like pregnancy announcements or any other big surprise moments.
 
 ## Opening the page
 
@@ -14,69 +14,28 @@ xdg-open index.html        # Linux
 
 ## Customizing via URL parameters
 
-`index.html` supports several query parameters so you can customize the reveal text and appearance. Parameters are optional and can be combined:
+`index.html` now recognizes just two optional query parameters so you can keep the experience simple:
 
-- `main` – main headline (default: "We are expecting!")
-- `sub` – secondary line of text
-- `date` – additional date or detail line
-- `photo` – URL to an image shown as a circular avatar
-- `from` – a closing signature line
-- `color` – overlay color when the message appears. Allowed values: `beige` (default), `pink`, `blue`, `yellow`, `green`, `purple`, `gold`, `white`, `none`. You can also supply any valid hex or CSS color value for a custom overlay.
-- `textColor` – color for the message text (any valid CSS color value)
-- `outlineColor` – color for the outline around the message text
-- `mainTextColor` – text color for the main headline
-- `mainOutlineColor` – outline color for the main headline
-- `subTextColor` – text color for the secondary line
-- `subOutlineColor` – outline color for the secondary line
-- `dateTextColor` – text color for the date line
-- `dateOutlineColor` – outline color for the date line
-- `fromTextColor` – text color for the closing signature
-- `fromOutlineColor` – outline color for the closing signature
-- `font` – Google Fonts family name to use for all text (e.g. `font=Playfair+Display`)
-- `fontMain` – font family for the main headline
-- `fontSub` – font family for the secondary line
-- `fontDate` – font family for the date line
-- `fontFrom` – font family for the closing signature
-- `s` – optional surprise code. Set `s=1` for a blue "IT'S A BOY!" reveal or `s=2` for a pink "IT'S A GIRL!" reveal, each with matching icons and confetti.
-- `lang` – optional locale code for built-in translations of the default reveal headline and gender message. Supported values include `en`, `es`, `fr`, `de`, `pt`, `it`, `nl`, `sv`, and `ar`. You can also use region-specific variants like `pt-BR`. Unknown values fall back to English. The alias `language` works as well.
+- `gender` – set to `boy` or `girl` to trigger the matching celebratory overlay on the fourth spin. When omitted, the slot machine simply reveals the neutral surprise message.
+- `lang` – choose the language used for the default messaging. The values `en`, `es`, `fr`, `de`, `pt`, `it`, `nl`, `sv`, and `ar` are supported, and region-specific variants such as `pt-BR` will fall back to their base language. The alias `language` is also accepted.
 
-Font parameters expect Google Fonts family names just like `font`, using `+` instead of spaces.
-
-Line-specific color parameters fall back to `textColor` and `outlineColor` if omitted.
-
-`color` only affects the overlay background, whereas `textColor` and `outlineColor` control the message text and its outline.
+All other URL parameters are ignored.
 
 ### Example links
 
 ```
-index.html?main=We%27re%20Engaged!&sub=Save%20the%20Date&date=June%202024
+index.html?gender=girl
 ```
 
 ```
-index.html?main=We%E2%80%99re%20expecting&font=Playfair+Display
+index.html?gender=boy&lang=es
 ```
 
 ```
-index.html?s=2
+index.html?lang=fr
 ```
 
-```
-index.html?s=1
-```
-
-```
-index.html?main=Congrats!&sub=You%20Did%20It&fontMain=Playfair+Display&fontSub=Roboto+Slab
-```
-
-```
-index.html?main=It%27s%20a%20Boy%21&photo=https%3A%2F%2Fexample.com%2Fbaby.jpg&from=Love%2C%20Alice%20and%20Bob&color=coral
-```
-
-```
-index.html?main=We%27re%20expecting%21&sub=Baby%20Miller%20%233&date=Arriving%20January%202026&photo=<url>&from=Love%2C%20Geoffrey%20and%20Kristina&color=beige&textColor=%23000000&outlineColor=%23888888
-```
-
-Open one of these URLs in your browser to see the customized reveal.
+Open one of these URLs in your browser to see the reveal tailored to your chosen gender and language.
 
 ## How the reel spinning works
 
@@ -90,6 +49,6 @@ removed and `createSingleIcon()` displays the final symbol for that reel.
 
 During the first three spins the grid stops on random symbols that never match
 across all three reels. On the fourth spin all reels are forced to stop on the
-bottle icon and `showReveal()` is triggered, revealing the personalized message
-overlay. Any spins after the reveal go back to being completely random, so
-matches can happen naturally.
+bottle icon and `showReveal()` is triggered, revealing the celebratory message
+overlay (and the gender announcement if you enabled it). Any spins after the
+reveal go back to being completely random, so matches can happen naturally.

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>The Big Reveal</title>
     <meta
       name="description"
-      content="A fun, personalized surprise reveal experience. Play and discover your message!"
+      content="A fun surprise reveal with optional gender and language selection."
     />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&display=swap"
@@ -226,12 +226,6 @@
         margin: 0;
         line-height: 1.15;
       }
-      .reveal-photo {
-        max-width: 90%;
-        max-height: 30vh;
-        object-fit: contain;
-        margin: 2vh 0;
-      }
       .reveal-line.main {
         line-height: 1.1;
         font-weight: 900;
@@ -417,77 +411,30 @@
       // -------------- URL Params Logic -------------
       function getParams() {
         const url = new URL(window.location.href);
-        const params = {};
-        for (const [k, v] of url.searchParams.entries()) {
-          // Normalize keys to lower case
-          const key = k.toLowerCase();
-          const value = v.replace(/\+/g, " ");
-          params[key] = value;
-          // Preserve original casing for backward compatibility
-          if (key !== k) params[k] = value;
-        }
-        return params;
+        const langParam = (
+          url.searchParams.get("lang") || url.searchParams.get("language") || ""
+        ).toLowerCase();
+        const genderParam = (url.searchParams.get("gender") || "").toLowerCase();
+        return { lang: langParam, gender: genderParam };
       }
 
-      const isValidHex = (str) => /^#([0-9A-F]{3}){1,2}$/i.test(str);
-
-      function sanitizeColor(value, fallback) {
-        if (!value) return fallback;
-        value = value.trim();
-        if (isValidHex(value)) return value;
-        const test = new Option().style;
-        test.color = value;
-        return test.color ? value : fallback;
-      }
-
-      function getRevealLinesFromParams(params, defaults = {}) {
-        // Defaults
+      function buildRevealLines(defaults = {}) {
         const lines = [];
-        let photo = params.photo ? decodeURIComponent(params.photo) : "";
-        // Only allow http:, https: or data:image/ URLs for images
-        if (photo && !/^(https?:|data:image\/)/i.test(photo)) {
-          photo = "";
-        }
-        const main = params.main || defaults.main || "We are expecting!";
-        const sub = params.sub || defaults.sub || "";
-        const date = params.date || defaults.date || "";
-        const from = params.from || defaults.from || "";
+        const main = defaults.main || "We are expecting!";
+        const sub = defaults.sub || "";
+        const date = defaults.date || "";
+        const from = defaults.from || "";
         if (main) lines.push({ type: "main", content: main });
         if (sub) lines.push({ type: "sub", content: sub });
         if (date) lines.push({ type: "date", content: date });
-        if (photo) lines.push({ type: "photo", content: photo });
         if (from) lines.push({ type: "from", content: from });
         return lines;
-      }
-      function getColorOverlay(params) {
-        // Pink, blue, yellow, green, purple, gold, white, none
-        const input = params.color ? params.color.trim() : "";
-        // Allow custom CSS colors
-        if (isValidHex(input)) return input;
-        const test = new Option().style;
-        test.color = input;
-        if (test.color) return input;
-
-        const color = (input || "beige").toLowerCase();
-        const overlays = {
-          beige: "#f3ddbb",
-          pink: "#fcc0c5",
-          blue: "#add4fd",
-          yellow: "#fef3c7",
-          green: "#cbf7d0",
-          purple: "#d2c5fc",
-          gold: "#ffdf9a",
-          white: "#ffffff",
-          none: "transparent",
-        };
-        return overlays[color] || overlays.beige;
       }
 
       document.addEventListener("DOMContentLoaded", function () {
         const params = getParams();
 
-        const languageParam = (params.lang || params.language || "").toLowerCase();
-        const normalizedLanguage = languageParam.split(/[-_]/)[0];
+        const normalizedLanguage = params.lang.split(/[-_]/)[0];
         const translations = {
           en: {
             htmlLang: "en",
@@ -616,7 +563,8 @@
         } else {
           document.documentElement.removeAttribute("dir");
         }
-        const revealDefaults = locale.revealDefaults || translations.en.revealDefaults;
+        const revealDefaults =
+          locale.revealDefaults || translations.en.revealDefaults;
         const genderTranslations = locale.gender || translations.en.gender;
 
         const icons = [
@@ -643,7 +591,6 @@
           "img/background.png",
           "img/tap to spin.png",
           "img/directions.png",
-          ...(params.photo ? [params.photo] : []),
         ]);
 
         function getRandomIcon() {
@@ -690,100 +637,49 @@
         );
         const genderOverlay = document.getElementById("genderOverlay");
         const genderText = genderOverlay.querySelector(".gender-text");
-        const surpriseCode = params.s;
-        const isGirl = surpriseCode === "2" || (params.gender || "").toLowerCase() === "girl";
-        const isBoy = surpriseCode === "1" || (params.gender || "").toLowerCase() === "boy";
-        genderText.textContent = isBoy
-          ? genderTranslations.boy
-          : genderTranslations.girl;
-        const safeTextColor = sanitizeColor(params.textcolor, "#ffffff");
-        const safeOutlineColor = sanitizeColor(params.outlinecolor, "#7e5e4f");
+        const isGirl = params.gender === "girl";
+        const isBoy = params.gender === "boy";
+        if (isBoy) {
+          genderText.textContent = genderTranslations.boy;
+        } else if (isGirl) {
+          genderText.textContent = genderTranslations.girl;
+        } else {
+          genderText.textContent = "";
+        }
+        const safeTextColor = "#ffffff";
+        const safeOutlineColor = "#7e5e4f";
 
         const lineColors = {
           main: {
-            text: sanitizeColor(params.maintextcolor, safeTextColor),
-            outline: sanitizeColor(params.mainoutlinecolor, safeOutlineColor),
+            text: safeTextColor,
+            outline: safeOutlineColor,
           },
           sub: {
-            text: sanitizeColor(params.subtextcolor, safeTextColor),
-            outline: sanitizeColor(params.suboutlinecolor, safeOutlineColor),
+            text: safeTextColor,
+            outline: safeOutlineColor,
           },
           date: {
-            text: sanitizeColor(params.datetextcolor, safeTextColor),
-            outline: sanitizeColor(params.dateoutlinecolor, safeOutlineColor),
+            text: safeTextColor,
+            outline: safeOutlineColor,
           },
           from: {
-            text: sanitizeColor(params.fromtextcolor, safeTextColor),
-            outline: sanitizeColor(params.fromoutlinecolor, safeOutlineColor),
+            text: safeTextColor,
+            outline: safeOutlineColor,
           },
+        };
+        const fonts = {
+          main: "'Poppins'",
+          sub: "'Poppins'",
+          date: "'Poppins'",
+          from: "'Poppins'",
         };
         const audioContext = new (window.AudioContext ||
           window.webkitAudioContext)();
 
-        // --------- Font loading logic ---------
-        function loadGoogleFont(familyParam) {
-          if (!familyParam) return Promise.resolve(null);
-          const familyName = familyParam.replace(/\+/g, " ");
-          const link = document.createElement("link");
-          link.href = `https://fonts.googleapis.com/css2?family=${familyParam}&display=swap`;
-          link.rel = "stylesheet";
-          document.head.appendChild(link);
-          return document.fonts
-            .load(`1em '${familyName}'`)
-            .then(() => `'${familyName}'`)
-            .catch(() => `'${familyName}'`);
-        }
-
-        const fonts = {
-          main: null,
-          sub: null,
-          date: null,
-          from: null,
-        };
-        const fontPromises = [];
-
-        // Global font applied via CSS variable
-        if (params.font) {
-          fontPromises.push(
-            loadGoogleFont(params.font).then((ff) => {
-              if (ff) {
-                document.documentElement.style.setProperty("--font-family", ff);
-                fonts.main = fonts.sub = fonts.date = fonts.from = ff;
-              }
-            })
-          );
-        }
-
-        fontPromises.push(
-          loadGoogleFont(params.fontmain).then((ff) => {
-            if (ff) fonts.main = ff;
-          })
-        );
-        fontPromises.push(
-          loadGoogleFont(params.fontsub).then((ff) => {
-            if (ff) fonts.sub = ff;
-          })
-        );
-        fontPromises.push(
-          loadGoogleFont(params.fontdate).then((ff) => {
-            if (ff) fonts.date = ff;
-          })
-        );
-        fontPromises.push(
-          loadGoogleFont(params.fontfrom).then((ff) => {
-            if (ff) fonts.from = ff;
-          })
-        );
-
-        Promise.all(fontPromises).then(() =>
-          document.fonts.ready.then(refitAllLines)
-        );
-
-
-
         // Set overlay color on reveal
-        colorOverlay.style.background = getColorOverlay(params);
-        introColorOverlay.style.background = getColorOverlay(params);
+        const overlayColor = "#f3ddbb";
+        colorOverlay.style.background = overlayColor;
+        introColorOverlay.style.background = overlayColor;
 
         // Hide instructions overlay
         function hideInstructionsOverlay() {
@@ -923,7 +819,6 @@
         }
 
         function fitRevealLine(el, type) {
-          if (type === "photo") return;
           textFit(el, {
             alignVert: true,
             alignHoriz: true,
@@ -939,6 +834,10 @@
             const type = Array.from(el.classList).find((c) => c !== "reveal-line");
             fitRevealLine(el, type);
           });
+        }
+
+        if (document.fonts && document.fonts.ready) {
+          document.fonts.ready.then(refitAllLines);
         }
 
         function applyTextStyles(el, color, outlineColor, fontFamily) {
@@ -957,7 +856,7 @@
 
         // ------------- REVEAL LOGIC -----------------
         function showReveal() {
-          const allLines = getRevealLinesFromParams(params, revealDefaults);
+          const allLines = buildRevealLines(revealDefaults);
           const mainLine = allLines.find((l) => l.type === "main");
           const otherLines = allLines.filter((l) => l.type !== "main");
           let confettiShown = false;
@@ -968,19 +867,8 @@
             function addLine(line) {
               const div = document.createElement("div");
               div.className = "reveal-line " + line.type;
-              if (line.type === "photo") {
-                const img = document.createElement("img");
-                img.src = line.content;
-                img.alt = "photo";
-                img.onerror = () => {
-                  div.style.display = "none";
-                };
-                img.className = "reveal-photo";
-                div.appendChild(img);
-              } else {
-                div.textContent =
-                  line.type === "sub" ? line.content.toUpperCase() : line.content;
-              }
+              div.textContent =
+                line.type === "sub" ? line.content.toUpperCase() : line.content;
               const colors = lineColors[line.type] || { text: safeTextColor, outline: safeOutlineColor };
               applyTextStyles(div, colors.text, colors.outline, fonts[line.type]);
               div.style.margin = "0";
@@ -989,9 +877,8 @@
             }
             const subLine = otherLines.find((l) => l.type === "sub");
             const dateLine = otherLines.find((l) => l.type === "date");
-            const photoLine = otherLines.find((l) => l.type === "photo");
             const fromLine = otherLines.find((l) => l.type === "from");
-            [subLine, dateLine, photoLine, fromLine]
+            [subLine, dateLine, fromLine]
               .filter(Boolean)
               .forEach(addLine);
             const hideDelay = 30000;


### PR DESCRIPTION
## Summary
- reduce the reveal page URL options to only accept gender and language selections
- streamline the script to remove color, font, and photo customization logic while keeping translations and gender overlays intact
- refresh the README and meta description to describe the simplified configuration and provide updated examples

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d35460c4b0832f8f9f49c82f6616f5