### PR TITLE
Center reveal message and add pulsing animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,15 +257,17 @@
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        width: 100%;
+        width: min(84%, 360px);
         height: 100%;
         gap: 2vh;
         padding: 2vh 3vw;
+        margin: 0 auto;
         box-sizing: border-box;
+        text-align: center;
       }
 
       .reveal-line {
-        flex: 1;
+        flex: 0 0 auto;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -278,6 +280,25 @@
         color: #fff;
         margin: 0;
         line-height: 1.15;
+        animation: reveal-pulse 2.8s ease-in-out infinite;
+        transform-origin: center;
+        will-change: transform, opacity;
+      }
+      @keyframes reveal-pulse {
+        0%,
+        100% {
+          transform: scale(1);
+          opacity: 1;
+        }
+        50% {
+          transform: scale(1.06);
+          opacity: 0.9;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .reveal-line {
+          animation: none;
+        }
       }
       .reveal-line.main {
         line-height: 1.1;


### PR DESCRIPTION
## Summary
- center the reveal text block within the slot-machine background so all lines stay aligned with the window
- add a gentle pulse animation to each reveal line while honoring prefers-reduced-motion

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d434afc984832f9c21251e91453656