### PR TITLE
Adjust reel icon sizing and overflow handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@
         align-items: center;
         justify-content: center;
         transition: transform 0.35s cubic-bezier(0.22, 0.61, 0.36, 1);
+        overflow: hidden;
       }
       @keyframes slot-spin-down {
         0% {
@@ -154,6 +155,7 @@
         transform: translate3d(0, 0, 0);
         backface-visibility: hidden;
         contain: paint;
+        overflow: hidden;
       }
       .reel-item {
         height: 100%;
@@ -174,12 +176,16 @@
         left: 65.1%;
         top: 33.9%;
       }
-      .reel-icon {
-        width: var(--icon-w);
-        height: var(--icon-h);
+      .reel img {
+        max-width: 75%;
+        max-height: 75%;
         object-fit: contain;
         display: block;
         margin: auto;
+      }
+      .reel-icon {
+        width: auto;
+        height: auto;
         background: transparent;
       }
       .spin-button {


### PR DESCRIPTION
## Summary
- ensure reel containers hide overflow for all nested structures to prevent icon bleed
- constrain reel icon images to 75% of their container with object-fit contain and centering
- remove fixed sizing on reel icons so they scale proportionally within the reel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d437b45c30832f83e540e8256c14d3