### PR TITLE
Add French and German localized assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,56 @@
       as="image"
       href="img/Assets/Spanish/girl-spanish.png"
     />
+    <link
+      rel="preload"
+      as="image"
+      href="img/Assets/French/background-french.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="img/Assets/French/taptospin-french.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="img/Assets/French/instructions-french.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="img/Assets/French/boy-french.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="img/Assets/French/girl-french.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="img/Assets/German/background-german.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="img/Assets/German/taptospin-german.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="img/Assets/German/instructions-german.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="img/Assets/German/boy-german.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="img/Assets/German/girl-german.png"
+    />
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/textfit/2.4.0/textFit.min.js"
       defer
@@ -589,6 +639,20 @@
           instructions: "img/Assets/Spanish/instructions-spanish.png",
           boyIcon: "img/Assets/Spanish/boy-spanish.png",
           girlIcon: "img/Assets/Spanish/girl-spanish.png",
+        },
+        fr: {
+          background: "img/Assets/French/background-french.png",
+          tapToSpin: "img/Assets/French/taptospin-french.png",
+          instructions: "img/Assets/French/instructions-french.png",
+          boyIcon: "img/Assets/French/boy-french.png",
+          girlIcon: "img/Assets/French/girl-french.png",
+        },
+        de: {
+          background: "img/Assets/German/background-german.png",
+          tapToSpin: "img/Assets/German/taptospin-german.png",
+          instructions: "img/Assets/German/instructions-german.png",
+          boyIcon: "img/Assets/German/boy-german.png",
+          girlIcon: "img/Assets/German/girl-german.png",
         },
       };
 


### PR DESCRIPTION
## Summary
- preload French and German localized backgrounds, spin prompts, instructions, and gender icons
- extend language asset map with French and German resources to mirror existing Spanish handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d439d6143c832f9caebee68bbde39b