### PR TITLE
Adjust landing text alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,10 +96,11 @@
         width: 100%;
         height: 100%;
         display: flex;
+        flex-direction: column;
         align-items: center;
-        justify-content: center;
+        justify-content: flex-start;
         text-align: center;
-        padding: 6% 7%;
+        padding: 6% 7% 7%;
         box-sizing: border-box;
         max-width: 100%;
         max-height: 100%;


### PR DESCRIPTION
## Summary
- adjust the landing intro text container flex alignment to keep the message centered horizontally but anchored toward the top
- tweak padding so the scaled text can occupy more of the available box while remaining within the textFit bounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d49630cba8832fbf1c0e935d7c64cd