### PR TITLE
Adjust marquee intro text fit margin

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,6 +646,8 @@
           return;
         }
 
+        const widthPadding = Math.max(8, availableWidth * 0.02);
+        const widthLimit = Math.max(0, availableWidth - widthPadding);
         const minFontSize = 8;
         const maxFontSize = Math.min(
           900,
@@ -662,7 +664,7 @@
           const mid = (low + high) / 2;
           textElement.style.fontSize = `${mid}px`;
           const fitsWithinWidth =
-            textElement.scrollWidth <= availableWidth + tolerance;
+            textElement.scrollWidth <= widthLimit + tolerance;
           const fitsWithinHeight =
             textElement.scrollHeight <= availableHeight + tolerance;
           if (fitsWithinWidth && fitsWithinHeight) {


### PR DESCRIPTION
## Summary
- add a width padding adjustment when fitting the intro marquee text
- ensure the marquee message scales slightly smaller to avoid clipping on the right edge

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e3f0bc1a38832f90063e42c8f58c84