### PR TITLE
Fix intro text fitting to respect container padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -640,16 +640,27 @@
         if (!textContainer || !textElement) {
           return;
         }
-        const availableWidth = textContainer.clientWidth;
-        const availableHeight = textContainer.clientHeight;
-        if (!availableWidth || !availableHeight) {
+        const computedStyles = window.getComputedStyle(textContainer);
+        const paddingLeft = parseFloat(computedStyles.paddingLeft) || 0;
+        const paddingRight = parseFloat(computedStyles.paddingRight) || 0;
+        const paddingTop = parseFloat(computedStyles.paddingTop) || 0;
+        const paddingBottom = parseFloat(computedStyles.paddingBottom) || 0;
+
+        const availableWidth = Math.max(
+          0,
+          textContainer.clientWidth - paddingLeft - paddingRight,
+        );
+        const availableHeight = Math.max(
+          0,
+          textContainer.clientHeight - paddingTop - paddingBottom,
+        );
+
+        if (availableWidth === 0 || availableHeight === 0) {
           return;
         }
 
-        const widthPadding = Math.max(8, availableWidth * 0.02);
-        const widthLimit = Math.max(0, availableWidth - widthPadding);
-        const heightPadding = Math.max(8, availableHeight * 0.04);
-        const heightLimit = Math.max(0, availableHeight - heightPadding);
+        const widthLimit = availableWidth;
+        const heightLimit = availableHeight;
         const minFontSize = 8;
         const maxFontSize = Math.min(
           900,


### PR DESCRIPTION
## Summary
- account for the intro text container's padding when calculating available width and height
- stop shrinking the fit bounds past the actual interior space to avoid clipping on the right edge

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e403c32d9c832f84e7bb798fafc3a5